### PR TITLE
homework08 solution added (ThreadPool)

### DIFF
--- a/src/main/kotlin/ru/tinkoff/fintech/homework/homework08/ThreadPool.kt
+++ b/src/main/kotlin/ru/tinkoff/fintech/homework/homework08/ThreadPool.kt
@@ -1,8 +1,10 @@
 package ru.tinkoff.fintech.homework.homework08
 
+import io.swagger.v3.oas.models.security.SecurityScheme.In
 import java.lang.Thread.currentThread
 import java.lang.Thread.sleep
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
 import java.util.concurrent.LinkedBlockingQueue
 
@@ -15,7 +17,7 @@ class ThreadPool(threadQuantity: Int) : Executor {
     private var isRunning = true
 
     init {
-        require(threadQuantity <= MAX_THREADS || threadQuantity > 0) {
+        require(threadQuantity in 1..MAX_THREADS) {
             "Thread quantity should be greater then 0 and less then $MAX_THREADS!"
         }
         repeat(threadQuantity) {
@@ -66,13 +68,19 @@ class ThreadPool(threadQuantity: Int) : Executor {
 
 fun main() {
 
+    val map: ConcurrentHashMap<Int, Int> = ConcurrentHashMap()
     val pool = ThreadPool(2)
     repeat(5) {
         pool.execute {
             println("started at ${currentThread().name}")
             sleep(1000)
+            map[it] = it
             println("stopped at ${currentThread().name}")
         }
     }
+    println("main thread continues his work")
     pool.shutdown()
+    println("current map size is ${map.size}")
+    sleep(5000)
+    println("map size after 5 sec is ${map.size}")
 }

--- a/src/main/kotlin/ru/tinkoff/fintech/homework/homework08/ThreadPool.kt
+++ b/src/main/kotlin/ru/tinkoff/fintech/homework/homework08/ThreadPool.kt
@@ -1,0 +1,78 @@
+package ru.tinkoff.fintech.homework.homework08
+
+import java.lang.Thread.currentThread
+import java.lang.Thread.sleep
+import java.util.*
+import java.util.concurrent.Executor
+import java.util.concurrent.LinkedBlockingQueue
+
+class ThreadPool(threadQuantity: Int) : Executor {
+
+    private val taskQueue: Queue<Runnable> = LinkedBlockingQueue()
+    private val threadList: MutableList<WorkerThread> = mutableListOf()
+
+    @Volatile
+    private var isRunning = true
+
+    init {
+        require(threadQuantity <= MAX_THREADS || threadQuantity > 0) {
+            "Thread quantity should be greater then 0 and less then $MAX_THREADS!"
+        }
+        repeat(threadQuantity) {
+            threadList.add(WorkerThread())
+            threadList.last().start()
+        }
+    }
+
+    override fun execute(command: Runnable?) {
+        requireNotNull(command) { "Runnable task can not be null!" }
+        check(isRunning) { "Thread pool is stopped and can not execute new tasks!" }
+        synchronized(taskQueue) {
+            taskQueue.add(command)
+            (taskQueue as Object).notify()
+        }
+    }
+
+    fun shutdown() {
+        isRunning = false
+        synchronized(taskQueue) {
+            (taskQueue as Object).notifyAll()
+        }
+    }
+
+    private inner class WorkerThread : Thread() {
+
+        override fun run() {
+            var task: Runnable?
+
+            while (isRunning || taskQueue.isNotEmpty()) {
+                synchronized(taskQueue) {
+                    while (isRunning && taskQueue.isEmpty()) {
+                        (taskQueue as Object).wait()
+                    }
+                    task = taskQueue.poll()
+                }
+                task?.run()
+            }
+        }
+
+    }
+
+    companion object {
+        const val MAX_THREADS = 5
+    }
+
+}
+
+fun main() {
+
+    val pool = ThreadPool(2)
+    repeat(5) {
+        pool.execute {
+            println("started at ${currentThread().name}")
+            sleep(1000)
+            println("stopped at ${currentThread().name}")
+        }
+    }
+    pool.shutdown()
+}

--- a/src/test/kotlin/ru/tinkoff/fintech/homework/homework08/ThreadPoolTest.kt
+++ b/src/test/kotlin/ru/tinkoff/fintech/homework/homework08/ThreadPoolTest.kt
@@ -1,0 +1,49 @@
+package ru.tinkoff.fintech.homework.homework08
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FeatureSpec
+import io.kotest.matchers.shouldBe
+import java.lang.Thread.sleep
+import java.util.concurrent.ConcurrentHashMap
+
+class ThreadPoolTest : FeatureSpec() {
+
+    init {
+
+        feature("test exceptions") {
+            scenario("illegal thread's count") {
+                shouldThrow<IllegalArgumentException> { ThreadPool(0) }
+                shouldThrow<IllegalArgumentException> { ThreadPool(6) }
+            }
+            scenario("runnable is null") {
+                shouldThrow<IllegalArgumentException> { ThreadPool(1).execute(null) }
+            }
+            scenario("adding tasks to stopped ThreadPool") {
+                shouldThrow<IllegalStateException> {
+                    val pool = ThreadPool(1)
+                    pool.shutdown()
+                    pool.execute { }
+                }
+            }
+        }
+
+        feature("normal work") {
+            val pool = ThreadPool(5)
+            val map = ConcurrentHashMap<Int, Int>()
+            repeat(5) {
+                pool.execute {
+                    map[it] = it
+                    sleep(10000)
+                }
+            }
+            pool.shutdown()
+            map shouldBe expectedMap
+        }
+
+    }
+
+    companion object {
+        private val expectedMap = ConcurrentHashMap(mapOf(0 to 0, 1 to 1, 2 to 2, 3 to 3, 4 to 4))
+    }
+
+}


### PR DESCRIPTION
Простой пул потоков - в конструкторе указываем количество потоков, которое выделяется для пула и не освобождается до получения команды `shutdown`, методом `execute` добавляем задачу для выполнения, методом `shutdown` запрещаем принимать новые задачи, доделываем все ранее принятые и освобождаем потоки.

От рекомендованной идеи использовать `iterrupt` для пробуждения потоков из режима ожидания при завершении работы пула отказался - так как в переданных на выполнение задачах (которые мы никак не контролируем) могут быть методы, реагирующие на прерывание потока, например:
```
pool.execute {
            doSomething()
            sleep(1000)
        }
```
Более логичным выглядит использование `notifyAll()` для пробуждения всех потоков при завершении работы.